### PR TITLE
Fixing PyPI broken pip install with pip git install and adding setup file

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ pip install py2cytoscape
 
 visJS2jupyter supports both Python 2.7 and 3.4.
 
-You can install visJS2jupyter using pip:
+You can install visJS2jupyter using pip github install (PyPI package upload is depricated and will not work):
 
 ```
-pip install visJS2jupyter
+pip install git+https://github.com/uscd-ccbb/visJS2jupyter
 ```
 
 In your Jupyter notebook, first import matplotlib:

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 setup(name = 'visJS2jupyter',
-	packages=['visJS2jupyter']
+	packages=find_packages(exclude=[]),
+	install_requires=['matplotlib','networkx','py2cytoscape']
+
 )

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,5 @@
+from setuptools import setup
+
+setup(name = 'visJS2jupyter',
+	packages=['visJS2jupyter']
+)


### PR DESCRIPTION
making a proper package so it can be installed via pip git+.  right now, the version on PyPI is out of date and not tracking this repository.  this will allow someone to install from github source (right now pip install loads a deprecated version that will not import).